### PR TITLE
Feature/oauth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="assets/tglr-logo-color.svg" width="400" height="200" />
 
 Togglr is an open source, feature flagging application written by H-E-B.  Togglr consists of 5 base components.
-- [API](https://github.com/HEB/togglr-api) - Spring Boot application to manage all interactions with Togglr DB and provide base functionality.
+- [API](https://github.com/HEB/togglr-api) - Spring Boot application to manage all interactions with Togglr DB, oauth provider (for single sign on) and provide base functionality.
 - [Client](https://github.com/HEB/togglr-client) - Spring Boot client written to abstract usage of The Togglr API.  Consumed as a JAR.
 - [Mysql DB](https://github.com/HEB/togglr-mysql) - Simple docker container with init scripts.  Meant to be replaced with a more permanent solution in production.
 - [UI](https://github.com/HEB/togglr-ui) - Nuxt/VueJS application for interacting with API and management of Feature Flags

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="assets/tglr-logo-color.svg" width="400" height="200" />
 
 Togglr is an open source, feature flagging application written by H-E-B.  Togglr consists of 5 base components.
-- [API](https://github.com/HEB/togglr-api) - Spring Boot application to manage all interactions with Togglr DB, oauth provider (for single sign on) and provide base functionality.
+- [API](https://github.com/HEB/togglr-api) - Spring Boot application to manage all interactions with Togglr DB, oauth2 provider (for single sign on) and provide base functionality.
 - [Client](https://github.com/HEB/togglr-client) - Spring Boot client written to abstract usage of The Togglr API.  Consumed as a JAR.
 - [Mysql DB](https://github.com/HEB/togglr-mysql) - Simple docker container with init scripts.  Meant to be replaced with a more permanent solution in production.
 - [UI](https://github.com/HEB/togglr-ui) - Nuxt/VueJS application for interacting with API and management of Feature Flags

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -66,5 +66,13 @@ services:
       - HEB_TOGGLR_CACHE-TIME=10000
       - REDIS_HOST=redis://togglr-redis
       - REDIS_PORT=6379
+      - HEBTOGGLROAUTHENABLED=false
+      - OAUTHCLIENTID=
+      - OAUTHCLIENTSECRET=
+      - OAUTHACCESSTOKENURI=
+      - OAUTHREDIRECTURL=
+      - OAUTHUSERAUTHORIZATIONURI=
+      - OAUTHUSERINFOURI=
+      - OAUTHUSERIDFIELD=
 volumes: 
   db_data:


### PR DESCRIPTION
This updates the docker-compose.yaml file to include the new oauth2 environment variables needed in the Spring app. These variables are elaborated on in the API's version of the README.md. The README.md in the main Togglr repository has been updated to mention that Togglr has single sign in option now. This is all for Github [issue #1](https://github.com/HEB/togglr/issues/1). JIRA ticket 24 is most relevant for this specific PR.  I will provide values for the docker-compose.yaml's new env variables in Slack. 